### PR TITLE
Fix installation step in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,13 +27,13 @@ git clone https://github.com/aws/aws-elastic-beanstalk-cli-setup.git
 On **Bash** and **Zsh**:
 
 ```shell
-./aws-elasticbeanstalk-cli-setup/scripts/bundled_installer
+./aws-elastic-beanstalk-cli-setup/scripts/bundled_installer
 ```
 
 In **PowerShell** or in a **Command Prompt** window:
 
 ```ps1
-.\aws-elasticbeanstalk-cli-setup\scripts\bundled_installer
+.\aws-elastic-beanstalk-cli-setup\scripts\bundled_installer
 ```
 
 **NOTE:** In PowerShell, upon executing `bundled_installer`, if you see an error with the message "execution of scripts is disabled on this system", set the [execution policy](https://docs.microsoft.com/en-us/powershell/module/microsoft.powershell.security/set-executionpolicy?view=powershell-6) to "RemoteSigned".


### PR DESCRIPTION
*Description of changes:*

The REAME supposes that the repository is cloned as 'aws-elasticbeanstalk-cli-setup',
however, it is actually cloned as 'aws-elastic-beanstalk-cli-setup'

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
