### PR TITLE
Prevent invocation of the 'eb' process within a shell

### DIFF
--- a/scripts/ebcli_installer.py
+++ b/scripts/ebcli_installer.py
@@ -93,7 +93,7 @@ def _exec_cmd(args):
     the return code of the subprocess to remain None. In all such cases, the
     wrapper will assume a failure and return a non-zero exit code.
     \"\"\"
-    p = subprocess.Popen(' '.join(args), shell=True)
+    p = subprocess.Popen(args)
     try:
         p.communicate()
     except KeyboardInterrupt:


### PR DESCRIPTION
*Description of changes:*

Invocation within the shell strips the '"'s out of arguments to 'eb' as documented in [1]. Python documentation recommends that when quotes are expected, as in the case of environment variables/tags, a list of arguments should be preferred.

[1] https://docs.python.org/3.4/library/subprocess.html?highlight=subprocess#frequently-used-arguments




By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
