### PR TITLE
Specify TLS1.2 as the security protocol to use while downloading Python MSI

### DIFF
--- a/scripts/install-python.ps1
+++ b/scripts/install-python.ps1
@@ -34,6 +34,7 @@ function Get-PythonMSI {
     $url = Get-PythonInstallationTarget
     $client = New-Object System.Net.WebClient
     try {
+        [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
         $client.DownloadFile($url, $PythonInstaller)
     } catch {
         Write-Host "Failed to download Python. The following exception was raised:" -ForegroundColor Red


### PR DESCRIPTION
*Description of changes:*

The download of the Python MSI requires a SSL/TLS channel, however. On some Windows systems, this needs to be manually setup. This commit ensures that the security protocol is set before the download of the Python MSI can be attempted.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
