### PR TITLE
Get around virtualenv bug by omitting --upgrade

### DIFF
--- a/scripts/install-python.ps1
+++ b/scripts/install-python.ps1
@@ -68,7 +68,7 @@ function Update-UserEnvironmentPath {
 
 function Install-Virtualenv {
     Write-StepTitle "Installing virtualenv"
-    Invoke-Expression "pip install virtualenv --target $PSScriptRoot\virtualenv --upgrade"
+    Invoke-Expression "pip install virtualenv --target $PSScriptRoot\virtualenv"
 }
 
 $PythonExecutable = Get-PythonExecutable


### PR DESCRIPTION
*Description of changes:*

There appears to be a bug in virtualenv which causes virtualenv to break
when --upgrade and --target are passed. This commit omits the --upgrade argument
which is not absolutely necessary to have

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
