### PR TITLE
Update readme with more troubleshooting instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,13 +46,14 @@ In **PowerShell** or in a **Command Prompt** window:
 
     ```shell
     apt-get install \
-        zlib1g-dev libssl-dev libncurses-dev libffi-dev \
-        libsqlite3-dev libreadline-dev libbz2-dev
+        build-essential zlib1g-dev libssl-dev libncurses-dev \
+        libffi-dev libsqlite3-dev libreadline-dev libbz2-dev
     ```
 
   - On **Amazon Linux/Fedora**, run:
 
     ```shell
+    yum group install "Development Tools"
     yum install \
         zlib-devel openssl-devel ncurses-devel libffi-devel \
         sqlite-devel.x86_64 readline-devel.x86_64 bzip2-devel.x86_64
@@ -73,6 +74,12 @@ In **PowerShell** or in a **Command Prompt** window:
       
       ```ps1
       Set-ExecutionPolicy RemoteSigned
+      ```
+    - If you encounter an error that states "No module named 'virtualenv'", then you can perform the following commands to remedy this issue:
+      ```ps1
+      pip uninstall -y virtualenv
+      pip install virtualenv
+      python.\aws-elastic-beanstalk-cli-setup\scripts\ebcli_installer.py
       ```
 
 #### 2.4. After installation

--- a/scripts/python_installer
+++ b/scripts/python_installer
@@ -183,7 +183,7 @@ function main() {
     echo_step_title "Checking whether Python can be downloaded (through curl, wget, or aria2c)"
     verify_http_client_exists
 
-    echo_step_title "Installing Python $PYTHON_VERSION"
+    echo_step_title "Installing Python $PYTHON_VERSION. This step may take a few minutes"
     install_python
 
     echo_step_title "Installing virtualenv using $PYENV_BIN/pip"


### PR DESCRIPTION
I've run through the setup script a handful of times and run into some problems that weren't addressed in the README, so this update simply adds those cases. It also updates the verbiage on the 'Installing Python' step to indicate that it might take some time.

Issue related to 'ModuleNotFound' : https://github.com/aws/aws-elastic-beanstalk-cli-setup/issues/19