### PR TITLE
Fix wget detection logic

### DIFF
--- a/scripts/python_installer
+++ b/scripts/python_installer
@@ -159,6 +159,8 @@ function verify_http_client_exists() {
     elif [[ "$(wget --version 2>/dev/null || true)" = "GNU Wget 1.1"[0-3]* ]]; then
         echo_error_message "wget (>= 1.14) or curl (>= 7.18.1) is required to download and install Python."
         exit 1
+    elif [ -n "$(wget --version 2>/dev/null)" ]; then
+        return
     else
         echo_error_message "Could not find \`curl\`, \`wget\`, or \`aria2c\`. Please install one of these tools to continue Python installation"
         exit 1


### PR DESCRIPTION
Detection of wget does not work. Detection of the presence of any supported download tool only checks if wget is present and too old. But if wget is present and it's not too old, the installation script behaves as if wget is missing.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.