### PR TITLE
[readme] add reference to brew info for env vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ In **PowerShell** or in a **Command Prompt** window:
     brew install zlib openssl readline
     CFLAGS="-I$(brew --prefix openssl)/include -I$(brew --prefix readline)/include -I$(xcrun --show-sdk-path)/usr/include" LDFLAGS="-L$(brew --prefix openssl)/lib -L$(brew --prefix readline)/lib -L$(brew --prefix zlib)/lib"
     ```
+    Run `brew info` to get the latest environment variable export suggestions, such as `brew info zlib`
 
 - **Windows**
 


### PR DESCRIPTION
I encountered a problem during installation where python could not find zlib. It appears there needs to be additional environment variables set, which are provided (and kept up to date) by the brew info command

*Issue*
installation instructions did not have relevant help to troubleshoot a problem
```
zipimport.ZipImportError: can't decompress data; zlib not available
make: *** [install] Error 1
```

*Description of changes:*
adds one little note to the readme


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
