### PR TITLE
Add steps on macOS troubleshotting

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Python, which the EBCLI Installer depends on, requires the following prerequisit
 - **macOS**
 
      ```shell
-     openssl zlib readline
+     Xcode openssl zlib readline
      ```
 
 ------
@@ -100,7 +100,7 @@ In **PowerShell** or in a **Command Prompt** window:
 - **Windows**
 
     - In PowerShell, if you encounter an error with the message "execution of scripts is disabled on this system", set the [execution policy](https://docs.microsoft.com/en-us/powershell/module/microsoft.powershell.security/set-executionpolicy?view=powershell-6) to `"RemoteSigned"` and then rerun `bundled_installer`.
-      
+
       ```ps1
       Set-ExecutionPolicy RemoteSigned
       ```


### PR DESCRIPTION
*Issue #, if available:*

https://github.com/aws/aws-elastic-beanstalk-cli-setup/issues/58

*Description of changes:*

* Added documentation about Xcode installation to fix troubleshooting with OpenSSL lib.
 
During the installation, after executing `brew install openssl`, I had the error `ERROR: The Python ssl extension was not compiled. Missing the OpenSSL lib?`. This error was fixed installing Xcode.

* Added documentation about Python version management installation:

I had the problem described in the issue #58  (when installing Python 3.7.2). This error gets fixed installing `pyenv` ([Python version management](https://github.com/pyenv/pyenv)).


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
