### PR TITLE
Don't override PYENV_ROOT if it is set

### DIFF
--- a/scripts/bundled_installer
+++ b/scripts/bundled_installer
@@ -8,7 +8,7 @@
 #   - the latest (or close to it) Python
 #   - the latest version of the EBCLI
 export PYTHON_VERSION="3.7.2"
-export PYENV_ROOT="$HOME/.pyenv"
+export PYENV_ROOT=${PYENV_ROOT:-"$HOME/.pyenv"}
 export PYENV_BIN="$PYENV_ROOT/versions/$PYTHON_VERSION/bin"
 BASH_PROFILE="$HOME/.bash_profile"
 ZSHENV="$HOME/.zshrc"


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Don't override `PYENV_ROOT` if it is set.
Before this change, `./script/bundled_installer` fails If pyenv is installed other than `${HOME}/.pyenv`. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
