### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,13 @@ Python, which the EBCLI Installer depends on, requires the following prerequisit
         ```shell
         build-essential zlib1g-dev libssl-dev libncurses-dev libffi-dev libsqlite3-dev libreadline-dev libbz2-dev
         ```
+        
+        _Note:_ `build-essential` is not a standard package and may need to be installed. For example, in Debian you would install it by running
+        
+        ```shell
+        sudo apt update
+        sudo apt install build-essential
+        ```
 
     - **Amazon Linux and Fedora**
 


### PR DESCRIPTION
Add note about installing `build-essential`

*Issue #, if available:*

*Description of changes:*

Adds a comment in the README explaining that you may have to install build-essential before you can proceed. This is in line with the comment a few lines above suggesting that you may need to install git.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
