### PR TITLE
Fix issue where script fails if installer is in a path with a special character in it.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 *.swp
 *.swo
 __pycache__
+.venv/

--- a/scripts/bundled_installer.ps1
+++ b/scripts/bundled_installer.ps1
@@ -17,25 +17,10 @@ function Get-HomePath() {
     }
 }
 
-function Exit-OnFailure {
-    param(
-        [validateset('application','powershell')]
-        [string]
-        $Type = 'application'
-    )
-    switch($Type) {
-        'application' {
-            if ($LASTEXITCODE -ne 0) {
-                Write-Host "Exiting due to failure" -ForegroundColor Red
-                exit 1
-            }
-        }
-        'powershell' {
-            if ($error.count -gt 0) {
-                Write-Host "Exiting due to failure" -ForegroundColor Red
-                exit 1
-            }
-        }
+function Exit-OnFailure() {
+    if ($LASTEXITCODE -ne 0) {
+        Write-Host "Exiting due to failure" -ForegroundColor Red
+        exit 1
     }
 }
 

--- a/scripts/bundled_installer.ps1
+++ b/scripts/bundled_installer.ps1
@@ -54,9 +54,11 @@ function Write-StepTitle([String] $Message) {
     Write-OutputWithInvertedColors $equals
 }
 Write-StepTitle "I. Installing Python                          "
-$Error.Clear()
-& "$PSScriptRoot\install-python.ps1"
-Exit-OnFailure -Type PowerShell
+try {
+    & "$PSScriptRoot\install-python.ps1"
+} catch {
+    Write-Error "Exiting due to failure" -ErrorAction Stop
+}
 Update-UserEnvironmentPath
 
 Write-StepTitle "II. Creating self-contained EBCLI installation"

--- a/scripts/bundled_installer.ps1
+++ b/scripts/bundled_installer.ps1
@@ -17,10 +17,25 @@ function Get-HomePath() {
     }
 }
 
-function Exit-OnFailure() {
-    if ($LASTEXITCODE -ne 0) {
-        Write-Host "Exiting due to failure" -ForegroundColor Red
-        exit 1
+function Exit-OnFailure {
+    param(
+        [validateset('application','powershell')]
+        [string]
+        $Type = 'application'
+    )
+    switch($Type) {
+        'application' {
+            if ($LASTEXITCODE -ne 0) {
+                Write-Host "Exiting due to failure" -ForegroundColor Red
+                exit 1
+            }
+        }
+        'powershell' {
+            if ($error.count -gt 0) {
+                Write-Host "Exiting due to failure" -ForegroundColor Red
+                exit 1
+            }
+        }
     }
 }
 
@@ -39,8 +54,9 @@ function Write-StepTitle([String] $Message) {
     Write-OutputWithInvertedColors $equals
 }
 Write-StepTitle "I. Installing Python                          "
-powershell "$PSScriptRoot\install-python.ps1"
-Exit-OnFailure
+$Error.Clear()
+& "$PSScriptRoot\install-python.ps1"
+Exit-OnFailure -Type PowerShell
 Update-UserEnvironmentPath
 
 Write-StepTitle "II. Creating self-contained EBCLI installation"

--- a/scripts/install-python.ps1
+++ b/scripts/install-python.ps1
@@ -40,7 +40,7 @@ function Get-PythonMSI {
         Write-Host "Failed to download Python. The following exception was raised:" -ForegroundColor Red
         Write-Host $_.exception -ForegroundColor Red
 
-        Exit 1
+        throw
     }
 }
 
@@ -51,11 +51,9 @@ function Install-Python {
     if ($install.ExitCode -eq 0) {
         Write-Host "Installation completed successfully." -ForegroundColor Green
     } elseif ($install.ExitCode -eq 1602) {
-        Write-Host "Installer was exited by the user." -ForegroundColor Red
-        Exit 1
+        throw "Installer was exited by the user."
     } else {
-        Write-Host "Installation failed with exit code $install.ExitCode" -ForegroundColor Red
-        Exit 1
+        throw "Installation failed with exit code $install.ExitCode"
     }
 }
 
@@ -68,6 +66,7 @@ function Update-UserEnvironmentPath {
 }
 
 function Install-Virtualenv {
+    param()
     Write-StepTitle "Installing virtualenv"
     Invoke-Expression "pip install virtualenv --target $PSScriptRoot\virtualenv"
 }
@@ -81,4 +80,5 @@ if ($PythonExecutable.count -eq 0) {
 } else {
     Write-Host "Python 3.7.3 is already installed." -ForegroundColor Green
 }
-Install-Virtualenv
+
+Install-Virtualenv -ErrorAction Stop


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:

Use invoke of a command in PowerShell instead of starting a new powershell so the quoted token will always be interpreted as a single command.

* Also, fixed up Install-python to behave like a powershell script in terms of errors, so that they can be handled simpler.
* Added, error handling so you have equivalent behavior of what you had before.

## example of the problem

* put the installer in C:\users\travis' example user\aws-ebs
* run the instruction to install from that directory

results: the installer fails with an error about expecting a `'` 

## Alternative fix

you could call powershell with the `-file` switch, but I don't see why the extra process is needed.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
