### PR TITLE
escapes double quotes in python install PATH user notifications

### DIFF
--- a/scripts/python_installer
+++ b/scripts/python_installer
@@ -87,11 +87,11 @@ function print_path_export_instructions() {
     echo_with_indentation ""
     echo_recommendation_message "   1. Bash:"
     echo_with_indentation ""
-    echo_recommendation_message "      echo 'export PATH="${PYENV_BIN}:\$PATH"' >> $BASH_PROFILE && source $BASH_PROFILE"
+    echo_recommendation_message "      echo 'export PATH=\"${PYENV_BIN}:\$PATH\"' >> $BASH_PROFILE && source $BASH_PROFILE"
     echo_with_indentation ""
     echo_recommendation_message "   2. Zsh:"
     echo_with_indentation ""
-    echo_recommendation_message "      echo 'export PATH="${PYENV_BIN}:\$PATH"' >> $ZSHENV && source $ZSHENV"
+    echo_recommendation_message "      echo 'export PATH=\"${PYENV_BIN}:\$PATH\"' >> $ZSHENV && source $ZSHENV"
 }
 
 function python_is_not_in_path() {


### PR DESCRIPTION
*Issue #, if available:*

Noticed that the PATH addition commands could not be copied and pasted at the end of the installation on Ubuntu 20.04, because the double quotes were not escaped.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
